### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,8 +2,6 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.all
-    # 記事一覧が新規投稿順に並ぶように記述します。
     @items = Item.order('created_at DESC')
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,8 +2,9 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
+    @items = Item.all
     # 記事一覧が新規投稿順に並ぶように記述します。
-    # @items = Item.order('created_at DESC')
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,5 +16,5 @@ class User < ApplicationRecord
   validates :password, format: { with: VALID_PASSWORD_REGEX }
 
   has_many :items
-# has_many :orders
+  # has_many :orders
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,26 +127,29 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
+      <% if @items.present? %>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>   
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# if  %>
+          <%# div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          <%# /div>
+          <%# end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,8 +158,9 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+      <% else %>
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
@@ -176,6 +180,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,6 @@
     </div>
     <ul class='item-lists'>
       <% if @items.present? %>
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>   
@@ -157,10 +156,7 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% else %>
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -179,8 +175,6 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,7 +134,6 @@
         <%= link_to "#" do %>   
         <div class='item-img-content'>
           <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
-
           <%# 商品が売れていればsold outを表示しましょう %>
           <%# if  %>
           <%# div class='sold-out'>
@@ -142,7 +141,6 @@
           <%# /div>
           <%# end %>
           <%# //商品が売れていればsold outを表示しましょう %>
-
         </div>
         <div class='item-info'>
           <h3 class='item-name'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,4 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
   resources :items, only: [:index, :new, :create]
-  
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :item do
-    image            {Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/factories/test.jpg')) }
+    image            { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/factories/test.jpg')) }
     name             { Faker::Name.initials(number: 4) }
     detail           { Faker::Lorem.sentence }
     category_id      { Faker::Number.between(from: 2, to: 11) }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Item, type: :model do
       it '画像が空では出品できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include "Image can't be blank"  
-      end     
+        expect(@item.errors.full_messages).to include "Image can't be blank"
+      end
 
       it 'nameが空では出品できない' do
         @item.name = ''
@@ -40,67 +40,67 @@ RSpec.describe Item, type: :model do
       end
 
       it 'category_id が空では出品できない' do
-        @item.category_id  = ''
+        @item.category_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Category can't be blank"
       end
 
       it 'category_id が1では出品できない' do
-        @item.category_id  = '1'
+        @item.category_id = '1'
         @item.valid?
         expect(@item.errors.full_messages).to include "Category can't be blank"
       end
 
       it 'status_idが空では出品できない' do
-        @item.status_id  = ''
+        @item.status_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Status can't be blank"
       end
 
       it 'status_idが1では出品できない' do
-        @item.status_id  = '1'
+        @item.status_id = '1'
         @item.valid?
         expect(@item.errors.full_messages).to include "Status can't be blank"
       end
 
       it 'delivery_cost_idが空では出品できない' do
-        @item.delivery_cost_id  = ''
+        @item.delivery_cost_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Delivery cost can't be blank"
       end
 
       it 'delivery_cost_idが1では出品できない' do
-        @item.delivery_cost_id  = '1'
+        @item.delivery_cost_id = '1'
         @item.valid?
         expect(@item.errors.full_messages).to include "Delivery cost can't be blank"
       end
 
       it 'prefecture_idが空では出品できない' do
-        @item.prefecture_id  = ''
+        @item.prefecture_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Prefecture can't be blank"
       end
 
       it 'prefecture_idが1では出品できない' do
-        @item.prefecture_id  = '1'
+        @item.prefecture_id = '1'
         @item.valid?
         expect(@item.errors.full_messages).to include "Prefecture can't be blank"
       end
-            
+
       it 'delivery_day_idが空では出品できない' do
-        @item.delivery_day_id  = ''
+        @item.delivery_day_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Delivery day can't be blank"
       end
-           
+
       it 'delivery_day_idが1では出品できない' do
-        @item.delivery_day_id  = '1'
+        @item.delivery_day_id = '1'
         @item.valid?
         expect(@item.errors.full_messages).to include "Delivery day can't be blank"
       end
 
       it 'priceが空では出品できない' do
-        @item.price  = ''
+        @item.price = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Price can't be blank"
       end
@@ -108,19 +108,19 @@ RSpec.describe Item, type: :model do
       it 'priceは300以上でないと出品できない' do
         @item.price = '200'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price must be greater than or equal to 300"
+        expect(@item.errors.full_messages).to include 'Price must be greater than or equal to 300'
       end
-      
+
       it 'priceは9,999,999以下でないと出品できない' do
         @item.price = '100000000'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price must be less than or equal to 9999999"
+        expect(@item.errors.full_messages).to include 'Price must be less than or equal to 9999999'
       end
-      
+
       it 'priceは半角数値でないと出品できない' do
         @item.price = '３００'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is not a number"
+        expect(@item.errors.full_messages).to include 'Price is not a number'
       end
     end
   end


### PR DESCRIPTION
# what
トップページに出品商品を表示

# why
商品一覧表示機能実装


商品のデータがない場合は、ダミー商品が表示されている動画
https://i.gyazo.com/8425d773e39fa9c3a1ed434844591811.gif

 商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://i.gyazo.com/87325d23c479979cc6142434fd359e91.gif
